### PR TITLE
Stored proc for address creation

### DIFF
--- a/migrations/V001_202502191748__Create_Addresses_Proc.sql
+++ b/migrations/V001_202502191748__Create_Addresses_Proc.sql
@@ -5,7 +5,8 @@ CREATE PROCEDURE Create_Address
     @postal_code VARCHAR(15),
     @city_name VARCHAR(150),
     @province_name VARCHAR(150),
-    @country_name VARCHAR(150)
+    @country_name VARCHAR(150),
+    @address_id INT OUTPUT
 AS
 BEGIN
     DECLARE 
@@ -44,5 +45,7 @@ BEGIN
 
     INSERT INTO addresses(street_number, street_name, suburb_id, city_id)
     VALUES (@street_number, @street_name, @suburb_id, @city_id);
+
+	SET @address_id = SCOPE_IDENTITY()
 END;
 GO


### PR DESCRIPTION
Created a stored proc that creates addresses, and wont create any unnecessary entries in the country, province, city and suburb tables.

Tested locally with the following:

EXEC Create_Address
    @street_number = '12',
    @street_name = 'Williams Street',
    @suburb_name = 'Banhoek',
    @postal_code = '7600',
    @city_name = 'Stellenbosch',
    @province_name = 'Western Cape',
    @country_name = 'South Africa'
GO